### PR TITLE
Fix CSP to allow email obfuscation scripts

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -62,7 +62,7 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "payment=(), usb=()"
     # CSP for tam.buzz domain
-    Content-Security-Policy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data: https:; img-src 'self' https://avatars.githubusercontent.com data:; connect-src 'self' https:; manifest-src 'self'; object-src 'none'; base-uri 'self'; frame-src 'self'; frame-ancestors 'none'; form-action 'self';"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' data: https:; img-src 'self' https://avatars.githubusercontent.com data:; connect-src 'self' https:; manifest-src 'self'; object-src 'none'; base-uri 'self'; frame-src 'self'; frame-ancestors 'none'; form-action 'self';"
     # Allow cross-origin requests (keeping for compatibility)
     Access-Control-Allow-Origin = "*"
     Access-Control-Allow-Methods = "GET, HEAD, OPTIONS"


### PR DESCRIPTION
Fixes the Content Security Policy to allow inline JavaScript used for email obfuscation on the privacy page. The CSP was blocking the email link from appearing.